### PR TITLE
Improved --disable-exit-code description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
         required: false
         default: './composer.lock'
     disable-exit-code:
-        description: 'Whether to fail when issues are detected (false by default)'
+        description: 'Whether to continue when issues are detected (false by default)'
         required: false
         default: 0
 outputs:


### PR DESCRIPTION
`--disable-exit-code` description said it wether to fail (false by default) which can easily be misinterpreted.