### PR TITLE
Update local-php-security-checker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.18-alpine AS builder
-RUN wget -O checker https://github.com/fabpot/local-php-security-checker/releases/download/v2.0.3/local-php-security-checker_2.0.3_linux_amd64
+RUN wget -O checker https://github.com/fabpot/local-php-security-checker/releases/download/v2.0.5/local-php-security-checker_2.0.5_linux_amd64
 RUN chmod 755 checker
 
 FROM scratch

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dependencies, use this action:
 
     steps:
         - uses: actions/checkout@v2
-        - uses: symfonycorp/security-checker-action@v3
+        - uses: symfonycorp/security-checker-action@v4
 
 To speed up security checks, you can cache the vulnerability database:
 
@@ -34,14 +34,14 @@ To speed up security checks, you can cache the vulnerability database:
           with:
               path: ~/.symfony/cache
               key: db
-        - uses: symfonycorp/security-checker-action@v3
+        - uses: symfonycorp/security-checker-action@v4
 
 If the `composer.lock` is not in the repository root directory, pass is as an
 input:
 
     steps:
         - uses: actions/checkout@v2
-        - uses: symfonycorp/security-checker-action@v3
+        - uses: symfonycorp/security-checker-action@v4
           with:
               lock: subdir/composer.lock
 
@@ -50,7 +50,7 @@ do something with them in another step:
 
     steps:
         - uses: actions/checkout@v2
-        - uses: symfonycorp/security-checker-action@v3
+        - uses: symfonycorp/security-checker-action@v4
           with:
               disable-exit-code: 1
           id: security-check


### PR DESCRIPTION
Would like this action to be updated to the latest local-php-security-checker which fixes the empty vulns output.