### PR TITLE
Migrate to Symfony CLI Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM golang:1.18-alpine AS builder
-RUN wget -O checker https://github.com/fabpot/local-php-security-checker/releases/download/v2.0.5/local-php-security-checker_2.0.5_linux_amd64
-RUN chmod 755 checker
-
-FROM scratch
-COPY --from=builder /go/checker /
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-CMD ["/checker"]

--- a/action.yml
+++ b/action.yml
@@ -21,11 +21,11 @@ outputs:
         description: 'The detected vulnerabilities as JSON'
 runs:
     using: 'docker'
-    image: 'Dockerfile'
+    image: 'docker://ghcr.io/symfony-cli/symfony-cli:v5'
     args:
-        - "/checker"
+        - "security:check"
         - "--format"
         - ${{ inputs.format }}
-        - "--path"
+        - "--dir"
         - ${{ inputs.lock }}
         - "--disable-exit-code=${{ inputs.disable-exit-code }}"


### PR DESCRIPTION
The advantage is that the image only needs to be pulled instead of being built so just a bit more efficient.
wdyt?

(If merged it would probably be best to tag a new version)